### PR TITLE
Removed failing class_exist()

### DIFF
--- a/src/ContaoAssetic/DefaultFilterFactory.php
+++ b/src/ContaoAssetic/DefaultFilterFactory.php
@@ -129,8 +129,6 @@ class DefaultFilterFactory
                 break;
 
             case 'cssMin':
-                if(class_exists("cssmin"))
-                {
                     if(file_exists(TL_ROOT . '/composer/vendor/mrclay/minify/min/lib/CSSmin.php'))
                     {
                         $filter = new MrclayCssMinFilter();
@@ -139,7 +137,6 @@ class DefaultFilterFactory
                     {
                         $filter = new CssMinFilter();
                     }
-                }
                 break;
 
             case 'cssRewrite':


### PR DESCRIPTION
``` php
if(class_exists("cssmin"))
```

always returns false, the class actually has various names like `CssMin`, `CSSmin`etc. (look at the case sensitivity).

This case has definitely to be refactored to a more dynamic solution, but at least with this fix it will work with https://github.com/mrclay/minify
